### PR TITLE
🐛 Fix missing import

### DIFF
--- a/src/pages/work.js
+++ b/src/pages/work.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { graphql } from "gatsby"
 
 import Layout from "../components/Layout"
 import SEO from "../components/SEO"


### PR DESCRIPTION
Fixes a missing import statement for graphql that caused a deprecation warning during the build process