### PR TITLE
Feature: `TextSmall` component

### DIFF
--- a/src/components/BlogList/BlogList.js
+++ b/src/components/BlogList/BlogList.js
@@ -10,14 +10,14 @@ const BlogListTitle = styled.h2`
 `
 
 const InternalLink = styled(Link)`
-  color: ${props => props.theme.colors.white};
+  color: ${props => props.theme.colors.white.default};
   display: block;
   font-size: ${props => props.theme.fontSize.lg};
   margin-bottom: ${props => props.theme.spacing[2]};
 `
 
 const ExternalLink = styled.a`
-  color: ${props => props.theme.colors.white};
+  color: ${props => props.theme.colors.white.default};
   display: block;
   font-size: ${props => props.theme.fontSize.lg};
   margin-bottom: ${props => props.theme.spacing[2]};

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,12 +1,14 @@
 import React from "react"
 import { Link } from "gatsby"
 
+import TextSmall from "../Typography/TextSmall"
+
 const Footer = () => (
   <div className="flex justify-between text-silver-darker mt-4 lg:max-w-4xl">
-    <span className="text-xs">&copy; 2019 — Rathes Sachchithananthan</span>
-    <Link className="text-xs" to="/legal">
+    <TextSmall>&copy; 2019 — Rathes Sachchithananthan</TextSmall>
+    <TextSmall element={Link} to="/legal">
       Legal Information
-    </Link>
+    </TextSmall>
   </div>
 )
 

--- a/src/components/OverviewInfo/index.js
+++ b/src/components/OverviewInfo/index.js
@@ -1,13 +1,14 @@
 import React from "react"
 import "./styles.css"
+import TextSmall from "../Typography/TextSmall"
 
 const OverviewInfo = () => (
   <ul className="flex justify-between my-16 overview-info md:max-w-sm">
     <li>
       <span className="block w-8 bg-white border-t border-white my-2" />
-      <span className="block tracking-wide text-xs text-silver leading-none">
+      <TextSmall color="silver" className="block tracking-wide leading-none">
         Working at
-      </span>
+      </TextSmall>
       <a
         className="text-white text-base font-bold xs:text-lg"
         href="https://www.teamleader.eu/"
@@ -17,9 +18,9 @@ const OverviewInfo = () => (
     </li>
     <li>
       <span className="block w-8 bg-white border-t border-white my-2" />
-      <span className="block tracking-wide text-xs text-silver leading-none">
+      <TextSmall color="silver" className="block tracking-wide leading-none">
         Living in
-      </span>
+      </TextSmall>
       <a
         className="text-white text-base font-bold xs:text-lg"
         href="https://goo.gl/maps/9kKByTYJhSz"
@@ -29,9 +30,9 @@ const OverviewInfo = () => (
     </li>
     <li>
       <span className="block w-8 bg-white border-t border-white my-2" />
-      <span className="block tracking-wide text-xs text-silver leading-none">
+      <TextSmall color="silver" className="block tracking-wide leading-none">
         Follow me
-      </span>
+      </TextSmall>
       <a
         className="text-white text-base font-bold xs:text-lg"
         href="https://twitter.com/rswebdesigner"

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,7 +1,7 @@
 import React from "react"
 
 const TextSmall = ({ children, element }) => {
-  const Element = element
+  const Element = element || "span"
 
   return <Element>{children}</Element>
 }

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,0 +1,3 @@
+const TextSmall = () => null
+
+export default TextSmall

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,7 +1,10 @@
 import React from "react"
+import styled from "styled-components"
 
 const TextSmall = ({ children, element }) => {
-  const Element = element || "span"
+  const Element = styled(element || "span")`
+    font-size: ${props => props.theme.fontSize.xs};
+  `
 
   return <Element>{children}</Element>
 }

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,9 +1,16 @@
 import React from "react"
 import styled from "styled-components"
 
-const TextSmall = ({ children, element, ...props }) => {
+const TextSmall = ({
+  children,
+  element,
+  color,
+  tint = "default",
+  ...props
+}) => {
   const Element = styled(element || "span")`
     font-size: ${props => props.theme.fontSize.xs};
+    color: ${props => (color ? props.theme.colors[color][tint] : undefined)};
   `
 
   return <Element {...props}>{children}</Element>

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,3 +1,9 @@
-const TextSmall = ({ children }) => children
+import React from "react"
+
+const TextSmall = ({ children, element }) => {
+  const Element = element
+
+  return <Element>{children}</Element>
+}
 
 export default TextSmall

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,12 +1,12 @@
 import React from "react"
 import styled from "styled-components"
 
-const TextSmall = ({ children, element }) => {
+const TextSmall = ({ children, element, ...props }) => {
   const Element = styled(element || "span")`
     font-size: ${props => props.theme.fontSize.xs};
   `
 
-  return <Element>{children}</Element>
+  return <Element {...props}>{children}</Element>
 }
 
 export default TextSmall

--- a/src/components/Typography/TextSmall.js
+++ b/src/components/Typography/TextSmall.js
@@ -1,3 +1,3 @@
-const TextSmall = () => null
+const TextSmall = ({ children }) => children
 
 export default TextSmall

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -1,0 +1,3 @@
+import TextSmall from "./TextSmall"
+
+export { TextSmall }

--- a/theme.js
+++ b/theme.js
@@ -10,7 +10,9 @@ export default {
       darker: "#CCC",
       darkest: "#AAA",
     },
-    white: "#FFF",
+    white: {
+      default: "#FFF",
+    },
   },
   fontFamily: {
     default: [


### PR DESCRIPTION
This PR introduces a TextSmall component for small-sized texts that currently use Tailwinds `text-xs` class name and replaces the occurrences of that class name with the new component.

This is another step towards #46 