### PR TITLE
🐛  Fixes that wrong test data set was removed

### DIFF
--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -3,7 +3,7 @@ import { extractBlogPosts, groupPostsByYear, getSortedGroups } from "./index"
 describe("utils", () => {
   it("extracts the internal blog posts from graphql data", () => {
     const data = {
-      allMarkdownRemark: {
+      allMdx: {
         edges: [
           {
             node: {


### PR DESCRIPTION
Instead of the remark edges, the MDX edges were deleted in the tests.

This PR fixes that.