### PR TITLE
🔥 Remove renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["config:base", ":preserveSemverRanges"]
-}


### PR DESCRIPTION
This PR removes renovate. After that, we will bring back dependabot which seems to be more reliable than renovate. (May also be a config issue but dependabot is more familiar to me)