### PR TITLE
🐛 Fix the SSR didn't render full CSS

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,7 @@
 import React from "react"
 import postcss from "postcss"
 import autoprefixer from "autoprefixer"
+import { renderToString } from "react-dom/server"
 
 import { getCssString } from "./stitches.config"
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,7 +4,12 @@ import autoprefixer from "autoprefixer"
 
 import { getCssString } from "./stitches.config"
 
-export const replaceRenderer = ({ setHeadComponents }) => {
+export const replaceRenderer = ({
+  bodyComponent,
+  setHeadComponents,
+  replaceBodyHTMLString,
+}) => {
+  const bodyHTML = renderToString(bodyComponent)
   const styles = getCssString()
 
   setHeadComponents([
@@ -14,5 +19,7 @@ export const replaceRenderer = ({ setHeadComponents }) => {
         __html: postcss([autoprefixer()]).process(styles),
       }}
     />,
+
+    replaceBodyHTMLString(bodyHTML),
   ])
 }


### PR DESCRIPTION
Just calling `getCssString()` only returns the initial values. It's only when the component is rendered that `getCssString()` value is populated. So without rendering the component upfront before calling getCssString will not return the CSS you need for that particular page.