### PR TITLE
Navigation Redesign

### DIFF
--- a/src/layouts/PageLayout/PageLayout.tsx
+++ b/src/layouts/PageLayout/PageLayout.tsx
@@ -50,9 +50,9 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      <main className="bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:px-16 lg:px-32">
+      <main className="bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50">
         <Navigation />
-        <div className="flex min-h-screen flex-col justify-between pt-32">
+        <div className="mx-auto flex min-h-screen max-w-xl flex-col justify-between pt-32">
           {children}
           <Footer />
         </div>

--- a/src/layouts/PageLayout/PageLayout.tsx
+++ b/src/layouts/PageLayout/PageLayout.tsx
@@ -50,7 +50,7 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      <main className="flex min-h-screen flex-col justify-between bg-neutral-50 p-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:p-16 lg:py-24 lg:px-32">
+      <main className="flex min-h-screen flex-col justify-between bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:px-16 lg:px-32">
         <Navigation />
         {children}
         <Footer />

--- a/src/layouts/PageLayout/PageLayout.tsx
+++ b/src/layouts/PageLayout/PageLayout.tsx
@@ -52,8 +52,10 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
       <main className="flex min-h-screen flex-col justify-between bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:px-16 lg:px-32">
         <Navigation />
-        {children}
-        <Footer />
+        <div className="mt-32">
+          {children}
+          <Footer />
+        </div>
       </main>
     </ThemeContext.Provider>
   )

--- a/src/layouts/PageLayout/PageLayout.tsx
+++ b/src/layouts/PageLayout/PageLayout.tsx
@@ -50,9 +50,9 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      <main className="flex min-h-screen flex-col justify-between bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:px-16 lg:px-32">
+      <main className="bg-neutral-50 px-8 font-sans text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50 md:px-16 lg:px-32">
         <Navigation />
-        <div className="mt-32">
+        <div className="flex min-h-screen flex-col justify-between pt-32">
           {children}
           <Footer />
         </div>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,7 +6,7 @@ import { List, ListItem, Paragraph, Meta, Heading1 } from "../components"
 const NotFoundPage = () => (
   <PageLayout>
     <Meta title="404: Not found" />
-    <div className="max-w-[640px]">
+    <div className="max-w-xl">
       <Heading1>
         Looks like you are looking for a page that does not exist.
       </Heading1>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -21,7 +21,7 @@ import books from "../../data/books.json"
 const AboutMe: React.FC<React.PropsWithChildren<NextPage>> = () => (
   <PageLayout>
     <Meta title="About me" />
-    <div className="max-w-[640px]">
+    <div className="max-w-xl">
       <Heading1>/raðiːs/</Heading1>
       <Paragraph>
         I'm Rathes Sachchithananthan, a web developer with interests not only in

--- a/src/pages/blog/[language]/[slug].tsx
+++ b/src/pages/blog/[language]/[slug].tsx
@@ -80,13 +80,13 @@ const Blogpost: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   return (
     <PageLayout>
       <Meta title={title} description={excerpt} meta={meta} />
-      <div className="max-w-[640px]">
+      <div className="max-w-xl">
         {image && (
           <ImageWrapper aspect="16/9">
             <Image src={image} fill sizes="704px" priority alt={title} />
           </ImageWrapper>
         )}
-        <h1 className="mb-2 mt-12 max-w-[640px] break-words font-sansDisplay text-xl font-semibold leading-tight text-slate-900 dark:text-slate-50 sm:text-2xl">
+        <h1 className="mb-2 mt-12 max-w-xl break-words font-sansDisplay text-xl font-semibold leading-tight text-slate-900 dark:text-slate-50 sm:text-2xl">
           {title}
         </h1>
         <MDXRemote {...source} components={components} scope={{ books }} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { PageLayout } from "../layouts"
 const IndexPage: React.FC<React.PropsWithChildren<NextPage>> = () => (
   <PageLayout>
     <Meta title="Home" />
-    <section>
+    <section className="mt-16">
       <h1 className="mb-8 max-w-xl break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
         I'm Rathes Sachchithananthan, a front-end engineer living in{" "}
         <Link underlined href="https://goo.gl/maps/E9c5uw5SLjSbLZ9G9">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,21 +8,21 @@ const IndexPage: React.FC<React.PropsWithChildren<NextPage>> = () => (
   <PageLayout>
     <Meta title="Home" />
     <section>
-      <h1 className="mb-8 max-w-[640px] break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
+      <h1 className="mb-8 max-w-xl break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
         I'm Rathes Sachchithananthan, a front-end engineer living in{" "}
         <Link underlined href="https://goo.gl/maps/E9c5uw5SLjSbLZ9G9">
           London
         </Link>{" "}
         interested in fitness, languages, books &amp; cooking.
       </h1>
-      <p className="mb-8 max-w-[640px] break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
+      <p className="mb-8 max-w-xl break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
         Currently, I work as a product engineer at{" "}
         <Link underlined href="https://www.intercom.com/">
           Intercom
         </Link>{" "}
         helping businesses building better customer relationships.
       </p>
-      <p className="mb-8 max-w-[640px] break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
+      <p className="mb-8 max-w-xl break-words font-sansDisplay text-xl font-medium leading-snug text-neutral-900 antialiased dark:text-neutral-50 sm:text-2xl">
         Find out more about me on{" "}
         <Link underlined href="https://twitter.com/rswebdesigner">
           Twitter

--- a/src/pages/reading-list.tsx
+++ b/src/pages/reading-list.tsx
@@ -33,7 +33,7 @@ const ReadingList: NextPage = () => {
   return (
     <PageLayout>
       <Meta title="Reading List" />
-      <div className="mb-32 max-w-[640px] flex-grow">
+      <div className="mb-32 max-w-xl flex-grow">
         <section className="mb-16 flex flex-col gap-4">
           <Heading1>Reading List</Heading1>
           <TextField

--- a/src/pages/talks/managing-time.tsx
+++ b/src/pages/talks/managing-time.tsx
@@ -7,7 +7,7 @@ import { Heading1, Paragraph, Meta } from "../../components"
 const ManagingTime: React.FC<React.PropsWithChildren<NextPage>> = () => (
   <PageLayout>
     <Meta title="You can't manage time - A talk about what people call time management"></Meta>
-    <div className="max-w-[640px]">
+    <div className="max-w-xl">
       <Heading1>
         You can't manage time
         <span className="block text-base text-neutral-500">

--- a/src/pages/talks/meetings.tsx
+++ b/src/pages/talks/meetings.tsx
@@ -7,7 +7,7 @@ import { Heading1, Paragraph, Meta } from "../../components"
 const Meetings: React.FC<React.PropsWithChildren<NextPage>> = () => (
   <PageLayout>
     <Meta title="You probably don't need that meeting - Developing a meeting culture that employees will love"></Meta>
-    <div className="max-w-[640px]">
+    <div className="max-w-xl">
       <Heading1>
         You probably don't need that meeting
         <span className="block text-base text-neutral-500">

--- a/src/pages/work.tsx
+++ b/src/pages/work.tsx
@@ -18,7 +18,7 @@ import { SayHi } from "../patterns"
 const Work: React.FC<React.PropsWithChildren<NextPage>> = () => {
   return (
     <PageLayout>
-      <section className="max-w-[640px]">
+      <section className="max-w-xl">
         <Meta title="Work" />
         <Heading1 className="sr-only">My work</Heading1>
         <Paragraph>

--- a/src/pages/writings.tsx
+++ b/src/pages/writings.tsx
@@ -18,7 +18,7 @@ const Writings: React.FC<
 > = ({ blogPosts }) => {
   return (
     <PageLayout>
-      <section className="max-w-[640px]">
+      <section className="max-w-xl">
         <Meta title="Writings" />
         <Paragraph>
           From time to time, I do write. Sometime on my blog, but also on other

--- a/src/patterns/Footer/Footer.tsx
+++ b/src/patterns/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 const Footer = () => (
-  <footer className="text-xs text-neutral-400 dark:text-neutral-600">
+  <footer className="mb-8 text-xs text-neutral-400 dark:text-neutral-600 md:mb-16 lg:mb-24">
     &copy; 2023 — Rathes Sachchithananthan
   </footer>
 )

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -8,7 +8,6 @@ import React, {
 } from "react"
 import Link, { LinkProps } from "next/link"
 
-import cx from "clsx"
 import { cva } from "class-variance-authority"
 
 import { ThemeContext } from "../../layouts/PageLayout/PageLayout"

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -151,7 +151,7 @@ const Navigation = () => {
 
   return (
     <nav
-      className={cx("inset-0 z-50", {
+      className={cx("inset-0 z-50 mt-8 md:mt-16 lg:mt-24", {
         "fixed bg-neutral-50 dark:bg-neutral-900": isOpen,
         "relative bg-transparent": !isOpen,
       })}
@@ -160,7 +160,7 @@ const Navigation = () => {
         className={cx(
           "box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50",
           {
-            "p-8 md:p-16 lg:py-24 lg:px-32": isOpen,
+            "p-8 md:p-16 lg:px-32 lg:py-24": isOpen,
             "mb-16 p-0 lg:mb-32": !isOpen,
           }
         )}

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -155,6 +155,16 @@ const TopBar: React.FC<PropsWithChildren<{ isOpen: boolean }>> = ({
   </div>
 )
 
+const menuBody = cva(
+  "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32",
+  {
+    variants: {
+      isOpen: { true: "fixed", false: "hidden" },
+    },
+    defaultVariants: { isOpen: false },
+  }
+)
+
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -193,15 +203,7 @@ const Navigation = () => {
           <Hamburger isOpen={isOpen} onToggle={toggleMenu} />
         </div>
       </TopBar>
-      <div
-        className={cx(
-          "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32",
-          {
-            fixed: isOpen,
-            hidden: !isOpen,
-          }
-        )}
-      >
+      <div className={menuBody({ isOpen })}>
         <div className="mt-8">
           <Heading4 className="text-neutral-500">Navigation</Heading4>
           <MenuItem href="/about">About</MenuItem>

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -180,11 +180,7 @@ const Navigation = () => {
     <nav>
       <TopBar isOpen={isOpen}>
         <div className="flex">
-          <Link
-            className="flex py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-            href="/"
-            aria-label="Home"
-          >
+          <Link href="/" aria-label="Home">
             <IconButton as="span">
               <Logo />
             </IconButton>

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -150,75 +150,76 @@ const Navigation = () => {
   }, [])
 
   return (
-    <nav
-      className={cx("inset-0 z-50 mt-8 md:mt-16 lg:mt-24", {
-        "fixed bg-neutral-50 dark:bg-neutral-900": isOpen,
-        "relative bg-transparent": !isOpen,
-      })}
-    >
+    <nav>
       <div
         className={cx(
-          "box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50",
+          "fixed inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
           {
-            "p-8 md:p-16 lg:px-32 lg:py-24": isOpen,
-            "mb-16 p-0 lg:mb-32": !isOpen,
+            "bg-neutral-50/70 dark:bg-neutral-900/70": !isOpen,
+            "bg-neutral-50/100 dark:bg-neutral-900/100": isOpen,
           }
         )}
       >
-        <div className="flex">
-          <Link
-            className="flex py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-            href="/"
-            aria-label="Home"
+        <div
+          className={cx(
+            "box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50"
+          )}
+        >
+          <div className="flex">
+            <Link
+              className="flex py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
+              href="/"
+              aria-label="Home"
+            >
+              <IconButton as="span">
+                <Logo />
+              </IconButton>
+            </Link>
+          </div>
+          <div className="flex">
+            <ThemeSwitch theme={theme} onToggle={toggleTheme}>
+              Toggle
+            </ThemeSwitch>
+            <Hamburger isOpen={isOpen} onToggle={toggleMenu} />
+          </div>
+        </div>
+      </div>
+      <div
+        className={cx(
+          "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32",
+          {
+            fixed: isOpen,
+            hidden: !isOpen,
+          }
+        )}
+      >
+        <div className="mt-8">
+          <Heading4 className="text-neutral-500">Navigation</Heading4>
+          <MenuItem href="/about">About</MenuItem>
+
+          <MenuItem href="/files/resume.pdf" aria-label="Resume">
+            Resume
+          </MenuItem>
+
+          <MenuItem href="/work">Work</MenuItem>
+
+          <MenuItem href="/writings">Writings</MenuItem>
+        </div>
+        <div className="mt-8">
+          <Heading4 className="text-neutral-500">Current Projects</Heading4>
+          <a
+            className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
+            href="https://learn-tamil.com"
           >
-            <IconButton as="span">
-              <Logo />
-            </IconButton>
-          </Link>
+            Learn Tamil
+          </a>
+          <a
+            className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
+            href="https://getmaxout.app"
+          >
+            Maxout
+          </a>
         </div>
-        <div className="flex">
-          <ThemeSwitch theme={theme} onToggle={toggleTheme}>
-            Toggle
-          </ThemeSwitch>
-          <Hamburger isOpen={isOpen} onToggle={toggleMenu} />
-        </div>
-      </div>
-      <div
-        className={cx("mt-8 px-8 md:px-16 lg:px-32", {
-          block: isOpen,
-          hidden: !isOpen,
-        })}
-      >
-        <Heading4 className="text-neutral-500">Navigation</Heading4>
-        <MenuItem href="/about">About</MenuItem>
-
-        <MenuItem href="/files/resume.pdf" aria-label="Resume">
-          Resume
-        </MenuItem>
-
-        <MenuItem href="/work">Work</MenuItem>
-
-        <MenuItem href="/writings">Writings</MenuItem>
-      </div>
-      <div
-        className={cx("mt-8 px-8 md:px-16 lg:px-32", {
-          block: isOpen,
-          hidden: !isOpen,
-        })}
-      >
-        <Heading4 className="text-neutral-500">Current Projects</Heading4>
-        <a
-          className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-          href="https://learn-tamil.com"
-        >
-          Learn Tamil
-        </a>
-        <a
-          className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-          href="https://getmaxout.app"
-        >
-          Maxout
-        </a>
       </div>
     </nav>
   )

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -129,7 +129,7 @@ const Hamburger: React.FC<
 }
 
 const topbar = cva(
-  "fixed inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
+  "fixed z-50 inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
   {
     variants: {
       isOpen: {

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -129,7 +129,7 @@ const Hamburger: React.FC<
 }
 
 const topbar = cva(
-  "fixed z-50 inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
+  "fixed z-50 inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700",
   {
     variants: {
       isOpen: {
@@ -148,14 +148,14 @@ const TopBar: React.FC<PropsWithChildren<{ isOpen: boolean }>> = ({
   children,
 }) => (
   <div className={topbar({ isOpen })}>
-    <div className="box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50">
+    <div className="mx-auto box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50">
       {children}
     </div>
   </div>
 )
 
 const menuBody = cva(
-  "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32",
+  "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32 [&_div]:max-w-xl [&_div]:mx-auto",
   {
     variants: {
       isOpen: { true: "fixed", false: "hidden" },

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -9,6 +9,7 @@ import React, {
 import Link, { LinkProps } from "next/link"
 
 import cx from "clsx"
+import { cva } from "class-variance-authority"
 
 import { ThemeContext } from "../../layouts/PageLayout/PageLayout"
 
@@ -128,6 +129,32 @@ const Hamburger: React.FC<
   )
 }
 
+const topbar = cva(
+  "fixed inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
+  {
+    variants: {
+      isOpen: {
+        true: "bg-neutral-50/100 dark:bg-neutral-900/100",
+        false: "bg-neutral-50/70 dark:bg-neutral-900/70",
+      },
+    },
+    defaultVariants: {
+      isOpen: false,
+    },
+  }
+)
+
+const TopBar: React.FC<PropsWithChildren<{ isOpen: boolean }>> = ({
+  isOpen,
+  children,
+}) => (
+  <div className={topbar({ isOpen })}>
+    <div className="box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50">
+      {children}
+    </div>
+  </div>
+)
+
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -151,39 +178,25 @@ const Navigation = () => {
 
   return (
     <nav>
-      <div
-        className={cx(
-          "fixed inset-x-0 mb-4 border-b border-neutral-200  px-6 py-2 backdrop-blur-sm dark:border-neutral-700  md:px-16 lg:px-32",
-          {
-            "bg-neutral-50/70 dark:bg-neutral-900/70": !isOpen,
-            "bg-neutral-50/100 dark:bg-neutral-900/100": isOpen,
-          }
-        )}
-      >
-        <div
-          className={cx(
-            "box-content flex max-w-xl items-center justify-between text-neutral-900 dark:text-neutral-50"
-          )}
-        >
-          <div className="flex">
-            <Link
-              className="flex py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-              href="/"
-              aria-label="Home"
-            >
-              <IconButton as="span">
-                <Logo />
-              </IconButton>
-            </Link>
-          </div>
-          <div className="flex">
-            <ThemeSwitch theme={theme} onToggle={toggleTheme}>
-              Toggle
-            </ThemeSwitch>
-            <Hamburger isOpen={isOpen} onToggle={toggleMenu} />
-          </div>
+      <TopBar isOpen={isOpen}>
+        <div className="flex">
+          <Link
+            className="flex py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
+            href="/"
+            aria-label="Home"
+          >
+            <IconButton as="span">
+              <Logo />
+            </IconButton>
+          </Link>
         </div>
-      </div>
+        <div className="flex">
+          <ThemeSwitch theme={theme} onToggle={toggleTheme}>
+            Toggle
+          </ThemeSwitch>
+          <Hamburger isOpen={isOpen} onToggle={toggleMenu} />
+        </div>
+      </TopBar>
       <div
         className={cx(
           "inset-0 mt-[65px] bg-neutral-900 px-8 md:px-16 lg:px-32",

--- a/src/patterns/Navigation/Navigation.tsx
+++ b/src/patterns/Navigation/Navigation.tsx
@@ -218,18 +218,8 @@ const Navigation = () => {
         </div>
         <div className="mt-8">
           <Heading4 className="text-neutral-500">Current Projects</Heading4>
-          <a
-            className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-            href="https://learn-tamil.com"
-          >
-            Learn Tamil
-          </a>
-          <a
-            className="block py-1 font-sansDisplay text-lg font-medium text-neutral-900 antialiased dark:text-neutral-50"
-            href="https://getmaxout.app"
-          >
-            Maxout
-          </a>
+          <MenuItem href="https://learn-tamil.com">Learn Tamil</MenuItem>
+          <MenuItem href="https://getmaxout.app">Maxout</MenuItem>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
This PR moves the navigation away from being part of the content to being a fixed element on the header. This redesign aims to make it easier to introduce more interactive elements to the website and thus make it feel more like an app than a plain content-based website.

**Before**
<img width="1470" alt="Screenshot 2023-03-31 at 7 47 21 PM" src="https://user-images.githubusercontent.com/6367520/229204685-3c7bffe5-3f17-4285-bc42-c7f9b9e53214.png">

**After**
<img width="1491" alt="Screenshot 2023-03-31 at 7 47 44 PM" src="https://user-images.githubusercontent.com/6367520/229204702-2e4de091-d2e0-4b5a-9ca0-563f4d7b25bd.png">
