### PR TITLE
Add blog post: "Are We All Just Builders Now?"

### DIFF
--- a/src/data/blog/en/are-we-all-just-builders-now.mdx
+++ b/src/data/blog/en/are-we-all-just-builders-now.mdx
@@ -1,0 +1,29 @@
+---
+title: Are We All Just Builders Now?
+date: 2026-03-10T00:00:00.000Z
+author: Rathes Sachchithananthan
+template: post
+description: "Something has been shifting quietly in product teams over the last year or two. What if the roles we've built our industry around are less permanent than we think?"
+categories:
+  - Life
+  - Tech
+locale: en_US
+---
+
+Something has been shifting quietly in product teams over the last year or two. I feel it, but I'm still not sure I can fully put my finger on it.
+
+What if the roles we've built our industry around — engineer, designer, product manager and even many other — are less permanent than we think?
+
+We as engineers are spending less and less time on the mechanical part of software engineering: Actually writing code. As someone who has specialized into requirement engineering, writing the actual code once I figured out the problem and solution felt like a chore. Now that AI handles most of that output, there is now space for thinking. Product thinking, design thinking, thinking about vision and customer experiences.
+
+At the same time, designers and PMs are starting to ship real, working things. No tickets needed, no design handover, no walkthroughs.
+
+And both directions are happening at once.
+
+As someone who's worn the founder hat, I've always wanted to understand every part of what I'm building. For a long time, the way our industry organizes itself felt like a constraint on that.
+
+You picked a lane. Even within engineering, it wasn't uncommon if you focused on being a front-end or back-end engineer. What excites me now is that this constraint is loosening. Not because depth stops mattering, but because the cost of crossing into adjacent territory has dropped dramatically.
+
+So here's what I keep thinking about: What if the natural endpoint of all this isn't better cross-functional collaboration, but the full dissolution of these functions themselves? Maybe the people building products in the future are just builders — each with a main focus, but without barriers around what they're allowed to touch or care about.
+
+I don't know if that's utopian or naive. Probably some of both. But the next generation entering the industry won't carry the same attachment to these titles that we do. They'll grow up building with AI from day one — and the idea of staying in your lane might feel as foreign to them as it always did to me.


### PR DESCRIPTION
## Summary
Added a new blog post exploring how product team roles are evolving in the era of AI-assisted development, questioning whether traditional role boundaries (engineer, designer, product manager) will dissolve into a unified "builder" role.

## Changes
- Added new blog post `src/data/blog/en/are-we-all-just-builders-now.mdx`
  - Published date: March 10, 2026
  - Author: Rathes Sachchithananthan
  - Categories: Life, Tech
  - Locale: en_US

## Content Overview
The post discusses:
- How AI is reducing the mechanical aspects of software engineering, freeing engineers to focus on product and design thinking
- Designers and PMs increasingly shipping working products without traditional handoff processes
- The loosening of specialization constraints as the cost of cross-functional work decreases
- A vision of future product builders who operate without rigid role boundaries, while maintaining depth in their primary focus areas